### PR TITLE
Add error event listeners on all metric streams

### DIFF
--- a/__tests__/layout.js
+++ b/__tests__/layout.js
@@ -126,8 +126,12 @@ test('Layout() - metrics properly decorated', async done => {
 
     layout.metrics.pipe(
         destObjectStream(arr => {
-            expect(arr[0].name).toBe('podlet_manifest_request');
-            expect(arr[3].name).toBe('podium_proxy_request');
+            expect(arr[0].name).toBe('context_run_parsers');
+            expect(arr[1].name).toBe('podlet_manifest_request');
+            expect(arr[2].name).toBe('podlet_fallback_request');
+            expect(arr[3].name).toBe('podlet_content_request');
+            expect(arr[4].name).toBe('context_run_parsers');
+            expect(arr[5].name).toBe('podium_proxy_request');
             done();
         }),
     );

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -100,30 +100,21 @@ const PodiumLayout = class PodiumLayout {
             value: new Metrics(),
         });
 
+        this.metrics.on('error', error => {
+            this.log.error('Error emitted by metric stream in @podium/layout module', error);
+        });
+
         const decorate = utils.decorateLayoutName(this.name);
 
-        this.client.metrics
-            .pipe(decorate)
-            .on('error', err => {
-                /* istanbul ignore next */
-                this.log.error(err);
-            })
-            .pipe(this.metrics)
-            .on('error', err => {
-                /* istanbul ignore next */
-                this.log.error(err);
-            });
+        decorate.on('error', error => {
+            this.log.error('Error emitted when decorating metric stream in @podium/layout module', error);
+        });
 
-        this.httpProxy.metrics
-            .pipe(decorate)
-            .on('error', err => {
-                /* istanbul ignore next */
-                this.log.error(err);
-            })
-            .on('error', err => {
-                /* istanbul ignore next */
-                this.log.error(err);
-            });
+        // Join metric streams
+        this.httpProxy.metrics.pipe(decorate);
+        this.context.metrics.pipe(decorate);
+        this.client.metrics.pipe(decorate);
+        decorate.pipe(this.metrics);
 
         this.client.registry.pipe(this.httpProxy.registry);
     }


### PR DESCRIPTION
This adds error event listeners on the metric stream. Guards against errors in the stream.