### PR TITLE
feat: asset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,177 @@ app.get(`${layout.pathname()}/bar/:id`, (req, res, next) => {
 });
 ```
 
+### .js(options)
+
+Sets and returns the pathname for a Layout's JavaScript assets. Defaults to an
+empty String.
+
+When a value is set it will be kept internally and returned when the method is called again.
+
+### options
+
+| option | type      | default | required |
+| ------ | --------- | ------- | -------- |
+| value  | `string`  |         |          |
+| prefix | `boolean` | `false` |          |
+
+#### value
+
+Used to set the pathname for the JavaScript assets for the Layout. The value
+can be a URL at which the Layout's user facing JavaScript is served. The value
+can be the [pathname] of a [URL] or an absolute URL.
+
+The value can only be set once. If called multiple times with a value, the
+method will throw. The method can, however, be called multiple times to
+retrieve the value.
+
+_Examples:_
+
+Serve a javascript file at `/assets/main.js`:
+
+```js
+const app = express();
+const layout = new Layout({
+    name: 'myLayout',
+    pathname: '/',
+});
+
+app.get(layout.js({ value: '/assets/main.js' }), (req, res) => {
+    res.status(200).sendFile('./app/assets/main.js', err => {});
+});
+```
+
+Serve assets statically along side the app and set a relative URI to the
+JavaScript file:
+
+```js
+const app = express();
+const layout = new Layout({
+    name: 'myLayout',
+    pathname: '/',
+});
+
+app.use('/assets', express.static('./app/files/assets'));
+layout.js({ value: '/assets/main.js' });
+```
+
+Set an absolute URL to where the JavaScript file is located:
+
+```js
+const layout = new Layout({
+    name: 'myLayout',
+    pathname: '/',
+});
+
+layout.js({ value: 'http://cdn.mysite.com/assets/js/e7rfg76.js' });
+```
+
+#### prefix
+
+Specify whether the method should prefix the return value with the value for
+`pathname` set in the constructor.
+
+_Examples:_
+
+Return the full pathname, `/foo/assets/main.js`, to the JavaScript assets:
+
+```js
+const app = express();
+const layout = new Layout({
+    name: 'myLayout',
+    pathname: '/foo',
+});
+
+layout.js({ value: '/assets/main.js', prefix: true });
+```
+
+Prefix will be ignored if the returned value is an absolute URL.
+
+### .css(pathname)
+
+Sets and returns the pathname for a Layout's CSS assets. Defaults to an empty
+String.
+
+When a value is set it will be kept internally and returned when the method is called again.
+
+### options
+
+| option | type      | default | required |
+| ------ | --------- | ------- | -------- |
+| value  | `string`  |         |          |
+| prefix | `boolean` | `false` |          |
+
+#### value
+
+Used to set the pathname for the CSS assets for the Layout. The value can be a
+URL at which the Layout's user facing CSS is served. The value can be the
+[pathname] of a [URL] or an absolute URL.
+
+The value can be set only once. If called multiple times with a value, the
+method will throw. The method can be called multiple times to retrieve the
+value though.
+
+_Examples:_
+
+Serve a CSS file at `/assets/main.css`:
+
+```js
+const app = express();
+const layout = new Layout({
+    name: 'myLayout',
+    pathname: '/',
+});
+
+app.get(layout.css({ value: '/assets/main.css' }), (req, res) => {
+    res.status(200).sendFile('./app/assets/main.css', err => {});
+});
+```
+
+Serve assets from a static file server and set a relative URI to the CSS file:
+
+```js
+const app = express();
+const layout = new Layout({
+    name: 'myLayout',
+    pathname: '/',
+});
+
+app.use('/assets', express.static('./app/files/assets'));
+layout.css({ value: '/assets/main.css' });
+```
+
+Set an absolute URL to where the CSS file is located:
+
+```js
+const layout = new Layout({
+    name: 'myLayout',
+    pathname: '/',
+});
+
+layout.css({ value: 'http://cdn.mysite.com/assets/css/3ru39ur.css' });
+```
+
+#### prefix
+
+Sets whether the method should prefix the return value with the value for
+`pathname` set in the constructor.
+
+_Examples:_
+
+Return the full pathname (`/foo/assets/main.css`) to the CSS assets:
+
+```js
+const app = express();
+const layout = new Layout({
+    name: 'myLayout',
+    pathname: '/foo',
+});
+
+layout.css({ value: '/assets/main.css', prefix: true });
+```
+
+Prefix will be ignored if the returned value is an absolute URL
+
 ### .client
 
 A property that exposes an instance of the [@podium/client] for fetching content

--- a/__tests__/layout.js
+++ b/__tests__/layout.js
@@ -25,6 +25,8 @@ const destObjectStream = done => {
     return dStream;
 };
 
+const DEFAULT_OPTIONS = { name: 'foo', pathname: '/' };
+
 /**
  * Constructor
  */
@@ -149,4 +151,130 @@ test('Layout() - metrics properly decorated', async done => {
     layout.metrics.push(null);
     s1.stop();
     s2.stop();
+});
+
+// #############################################
+// .css()
+// #############################################
+
+test('.css() - call method with no arguments - should return default value', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    const result = layout.css();
+    expect(result).toEqual('');
+});
+
+test('.css() - set legal value on "value" argument - should return set value', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+
+    const result = layout.css({ value: '/foo/bar' });
+
+    expect(result).toEqual('/foo/bar');
+});
+
+test('.css() - set "prefix" argument to "true" - should prefix value returned by method', () => {
+    const options = Object.assign({}, DEFAULT_OPTIONS, {
+        pathname: '/xyz',
+    });
+    const layout = new Layout(options);
+
+    const result = layout.css({ value: '/foo/bar', prefix: true });
+
+    expect(result).toEqual('/xyz/foo/bar');
+});
+
+test('.css() - set legal absolute value on "value" argument - should set "css" to set value', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    const result = layout.css({ value: 'http://somewhere.remote.com' });
+    expect(result).toEqual('http://somewhere.remote.com');
+});
+
+test('.css() - set illegal value on "value" argument - should throw', () => {
+    expect.hasAssertions();
+    const layout = new Layout(DEFAULT_OPTIONS);
+
+    expect(() => {
+        layout.css({ value: '/foo / bar' });
+    }).toThrowError(
+        'Value on argument variable "value", "/foo / bar", is not valid',
+    );
+});
+
+test('.css() - call method with "value" argument, then call it a second time with no argument - should return first set value on second call', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.css({ value: '/foo/bar' });
+    const result = layout.css();
+    expect(result).toEqual('/foo/bar');
+});
+
+test('.css() - call method twice with a value for "value" argument - should throw', () => {
+    expect.hasAssertions();
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.css({ value: '/foo/bar' });
+
+    expect(() => {
+        layout.css({ value: '/foo/bar' });
+    }).toThrowError('Value for "css" has already been set');
+});
+
+// #############################################
+// .js()
+// #############################################
+
+test('.js() - call method with no arguments - should return default value', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    const result = layout.js();
+    expect(result).toEqual('');
+});
+
+test('.js() - set legal value on "value" argument - should return set value', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+
+    const result = layout.js({ value: '/foo/bar' });
+
+    expect(result).toEqual('/foo/bar');
+});
+
+test('.js() - set "prefix" argument to "true" - should prefix value returned by method', () => {
+    const options = Object.assign({}, DEFAULT_OPTIONS, {
+        pathname: '/xyz',
+    });
+    const layout = new Layout(options);
+
+    const result = layout.js({ value: '/foo/bar', prefix: true });
+
+    expect(result).toEqual('/xyz/foo/bar');
+});
+
+test('.js() - set legal absolute value on "value" argument - should set "js" to set value', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    const result = layout.js({ value: 'http://somewhere.remote.com' });
+    expect(result).toEqual('http://somewhere.remote.com');
+});
+
+test('.js() - set illegal value on "value" argument - should throw', () => {
+    expect.hasAssertions();
+    const layout = new Layout(DEFAULT_OPTIONS);
+
+    expect(() => {
+        layout.js({ value: '/foo / bar' });
+    }).toThrowError(
+        'Value on argument variable "value", "/foo / bar", is not valid',
+    );
+});
+
+test('.js() - call method with "value" argument, then call it a second time with no argument - should return first set value on second call', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.js({ value: '/foo/bar' });
+    const result = layout.js();
+    expect(result).toEqual('/foo/bar');
+});
+
+test('.js() - call method twice with a value for "value" argument - should throw', () => {
+    expect.hasAssertions();
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.js({ value: '/foo/bar' });
+
+    expect(() => {
+        layout.js({ value: '/foo/bar' });
+    }).toThrowError('Value for "js" has already been set');
 });

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -16,6 +16,7 @@ const joi = require('joi');
 const utils = require('./utils');
 
 const _pathname = Symbol('_pathname');
+const _sanitize = Symbol('_sanitize');
 
 const PodiumLayout = class PodiumLayout {
     /* istanbul ignore next */
@@ -45,6 +46,16 @@ const PodiumLayout = class PodiumLayout {
                     `The value, "${pathname}", for the required argument "pathname" on the Layout constructor is not defined or not valid.`,
                 ),
             ),
+        });
+
+        Object.defineProperty(this, 'cssRoute', {
+            value: '',
+            writable: true,
+        });
+
+        Object.defineProperty(this, 'jsRoute', {
+            value: '',
+            writable: true,
         });
 
         Object.defineProperty(this, 'log', {
@@ -101,13 +112,19 @@ const PodiumLayout = class PodiumLayout {
         });
 
         this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/layout module', error);
+            this.log.error(
+                'Error emitted by metric stream in @podium/layout module',
+                error,
+            );
         });
 
         const decorate = utils.decorateLayoutName(this.name);
 
         decorate.on('error', error => {
-            this.log.error('Error emitted when decorating metric stream in @podium/layout module', error);
+            this.log.error(
+                'Error emitted when decorating metric stream in @podium/layout module',
+                error,
+            );
         });
 
         // Join metric streams
@@ -132,6 +149,50 @@ const PodiumLayout = class PodiumLayout {
         return s2;
     }
 
+    css({ value = null, prefix = false } = {}) {
+        if (!value) {
+            return this[_sanitize](this.cssRoute, prefix);
+        }
+
+        if (this.cssRoute) {
+            throw new Error('Value for "css" has already been set');
+        }
+
+        joi.attempt(
+            value,
+            schemas.manifest.css,
+            new Error(
+                `Value on argument variable "value", "${value}", is not valid`,
+            ),
+        );
+
+        this.cssRoute = this[_sanitize](value);
+
+        return this[_sanitize](this.cssRoute, prefix);
+    }
+
+    js({ value = null, prefix = false } = {}) {
+        if (!value) {
+            return this[_sanitize](this.jsRoute, prefix);
+        }
+
+        if (this.jsRoute) {
+            throw new Error('Value for "js" has already been set');
+        }
+
+        joi.attempt(
+            value,
+            schemas.manifest.js,
+            new Error(
+                `Value on argument variable "value", "${value}", is not valid`,
+            ),
+        );
+
+        this.jsRoute = this[_sanitize](value);
+
+        return this[_sanitize](this.jsRoute, prefix);
+    }
+
     middleware() {
         return (req, res, next) => {
             const incoming = new HttpIncoming(req, res, res.locals);
@@ -139,7 +200,11 @@ const PodiumLayout = class PodiumLayout {
             this.process(incoming)
                 .then(result => {
                     if (result) {
-                        putils.setAtLocalsPodium(res, 'context', incoming.context);
+                        putils.setAtLocalsPodium(
+                            res,
+                            'context',
+                            incoming.context,
+                        );
                         next();
                     }
                 })
@@ -151,6 +216,16 @@ const PodiumLayout = class PodiumLayout {
 
     pathname() {
         return this[_pathname];
+    }
+
+    [_sanitize](uri, prefix = false) {
+        const pathname = prefix ? this.pathname() : '';
+        if (uri) {
+            return putils.uriIsRelative(uri)
+                ? putils.pathnameBuilder(pathname, uri)
+                : uri;
+        }
+        return uri;
     }
 };
 


### PR DESCRIPTION
This pull request adds `.js()` and `.css()` methods to @podium/layout, in a similar vein to @podium/podlet. In fact, most of the changes here are are in fact copy pasted.

This resolves https://github.com/podium-lib/issues/issues/13