### PR TITLE
Use new schema to validate arguments

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const { HttpIncoming } = require('@podium/utils');
-const schemas = require('@podium/schemas');
+const { validate } = require('@podium/schemas');
 const Context = require('@podium/context');
 const Metrics = require('@metrics/client');
 const Client = require('@podium/client');
@@ -11,7 +11,6 @@ const abslog = require('abslog');
 const Proxy = require('@podium/proxy');
 const merge = require('lodash.merge');
 const putils = require('@podium/utils');
-const joi = require('joi');
 
 const { template } = putils;
 
@@ -30,24 +29,20 @@ const PodiumLayout = class PodiumLayout {
         client = {},
         proxy = {},
     } = {}) {
+        if (validate.name(name).error) throw new Error(
+            `The value, "${name}", for the required argument "name" on the Layout constructor is not defined or not valid.`
+        );
+
+        if (validate.uri(pathname).error) throw new Error(
+            `The value, "${pathname}", for the required argument "pathname" on the Layout constructor is not defined or not valid.`
+        );
+
         Object.defineProperty(this, 'name', {
-            value: joi.attempt(
-                name,
-                schemas.manifest.name,
-                new Error(
-                    `The value, "${name}", for the required argument "name" on the Layout constructor is not defined or not valid.`,
-                ),
-            ),
+            value: name,
         });
 
         Object.defineProperty(this, _pathname, {
-            value: joi.attempt(
-                pathname,
-                schemas.manifest.uri,
-                new Error(
-                    `The value, "${pathname}", for the required argument "pathname" on the Layout constructor is not defined or not valid.`,
-                ),
-            ),
+            value: pathname,
         });
 
         Object.defineProperty(this, 'cssRoute', {
@@ -166,12 +161,8 @@ const PodiumLayout = class PodiumLayout {
             throw new Error('Value for "css" has already been set');
         }
 
-        joi.attempt(
-            value,
-            schemas.manifest.css,
-            new Error(
-                `Value on argument variable "value", "${value}", is not valid`,
-            ),
+        if (validate.css(value).error) throw new Error(
+            `Value on argument variable "value", "${value}", is not valid`,
         );
 
         this.cssRoute = this[_sanitize](value);
@@ -188,12 +179,8 @@ const PodiumLayout = class PodiumLayout {
             throw new Error('Value for "js" has already been set');
         }
 
-        joi.attempt(
-            value,
-            schemas.manifest.js,
-            new Error(
-                `Value on argument variable "value", "${value}", is not valid`,
-            ),
+        if (validate.js(value).error) throw new Error(
+            `Value on argument variable "value", "${value}", is not valid`,
         );
 
         this.jsRoute = this[_sanitize](value);

--- a/package.json
+++ b/package.json
@@ -35,10 +35,9 @@
     "@podium/client": "3.0.6",
     "@podium/context": "3.0.3",
     "@podium/proxy": "^4.0.0-next",
-    "@podium/schemas": "3.0.0",
+    "@podium/schemas": "^4.0.0-next",
     "@podium/utils": "^4.0.0-next",
     "abslog": "2.4.0",
-    "joi": "^14.3.1",
     "lodash.merge": "^4.6.1",
     "readable-stream": "^3.2.0"
   },


### PR DESCRIPTION
Follow ups https://github.com/podium-lib/issues/issues/9. Use the new JSON Schema to validate arguments.

**NOTE:** one test is failing due to the validation rule. Seems like the `uri` validator does accept empty values. This must be fixed in the schema.