### PR TITLE
Make sure incoming is set correctly

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -4,7 +4,6 @@
 
 const {
     HttpIncoming,
-    setAtLocalsPodium,
     template,
     isFunction,
     pathnameBuilder,
@@ -13,6 +12,7 @@ const {
 const { validate } = require('@podium/schemas');
 const Context = require('@podium/context');
 const Metrics = require('@metrics/client');
+const objobj = require('objobj');
 const Client = require('@podium/client');
 const abslog = require('abslog');
 const Proxy = require('@podium/proxy');
@@ -229,7 +229,10 @@ const PodiumLayout = class PodiumLayout {
                 // if this is a proxy request then no further work should be done.
                 if (incoming.proxy) return;
 
-                setAtLocalsPodium(res, 'context', incoming.context);
+                // setAtLocalsPodium(res, 'context', incoming.context);
+                // set "incoming" on res.locals.podium
+                objobj.set('locals.podium', incoming, res);
+
                 res.podiumSend = data => res.send(this.render(incoming, data));
 
                 next();

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -229,7 +229,6 @@ const PodiumLayout = class PodiumLayout {
                 // if this is a proxy request then no further work should be done.
                 if (incoming.proxy) return;
 
-                // setAtLocalsPodium(res, 'context', incoming.context);
                 // set "incoming" on res.locals.podium
                 objobj.set('locals.podium', incoming, res);
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@podium/schemas": "4.0.0-next.3",
     "@podium/utils": "4.0.0-next.2",
     "abslog": "2.4.0",
+    "objobj": "^1.0.0",
     "lodash.merge": "^4.6.1",
     "readable-stream": "^3.2.0"
   },


### PR DESCRIPTION
Make sure we set the `HttpIncoming` on `res.locals.podium` in Express middleware. Previously we did only set the context on `res.locals.podium`, now we are setting the whole `HttpIncoming` object.

This caused the context not being passed down to podlets.