### PR TITLE
Remove limitation of how many assets which can be set

### DIFF
--- a/__tests__/layout.js
+++ b/__tests__/layout.js
@@ -283,14 +283,13 @@ test('.css() - call method with "value" argument, then call it a second time wit
     expect(result).toEqual('/foo/bar');
 });
 
-test('.css() - call method twice with a value for "value" argument - should throw', () => {
-    expect.hasAssertions();
+test('.css() - call method twice with a value for "value" argument - should set both values', () => {
     const layout = new Layout(DEFAULT_OPTIONS);
     layout.css({ value: '/foo/bar' });
+    layout.css({ value: '/bar/foo' });
 
-    expect(() => {
-        layout.css({ value: '/foo/bar' });
-    }).toThrowError('Value for "css" has already been set');
+    const result = layout.css();
+    expect(result).toEqual('/foo/bar');
 });
 
 // #############################################
@@ -346,14 +345,13 @@ test('.js() - call method with "value" argument, then call it a second time with
     expect(result).toEqual('/foo/bar');
 });
 
-test('.js() - call method twice with a value for "value" argument - should throw', () => {
-    expect.hasAssertions();
+test('.js() - call method twice with a value for "value" argument - should set both values', () => {
     const layout = new Layout(DEFAULT_OPTIONS);
     layout.js({ value: '/foo/bar' });
+    layout.js({ value: '/bar/foo' });
 
-    expect(() => {
-        layout.js({ value: '/foo/bar' });
-    }).toThrowError('Value for "js" has already been set');
+    const result = layout.js();
+    expect(result).toEqual('/foo/bar');
 });
 
 test('Layout() - rendering using an object', async () => {

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -19,6 +19,7 @@ const Proxy = require('@podium/proxy');
 const merge = require('lodash.merge');
 const pkg = require('../package.json');
 
+const _compabillity = Symbol('_compabillity');
 const _pathname = Symbol('_pathname');
 const _sanitize = Symbol('_sanitize');
 
@@ -51,13 +52,11 @@ const PodiumLayout = class PodiumLayout {
         });
 
         Object.defineProperty(this, 'cssRoute', {
-            value: '',
-            writable: true,
+            value: [],
         });
 
         Object.defineProperty(this, 'jsRoute', {
-            value: '',
-            writable: true,
+            value: [],
         });
 
         Object.defineProperty(this, 'log', {
@@ -171,40 +170,38 @@ const PodiumLayout = class PodiumLayout {
 
     css({ value = null, prefix = false } = {}) {
         if (!value) {
-            return this[_sanitize](this.cssRoute, prefix);
+            const v = this[_compabillity](this.cssRoute);
+            return this[_sanitize](v, prefix);
         }
 
-        if (this.cssRoute) {
-            throw new Error('Value for "css" has already been set');
-        }
+        if (validate.css(value).error) throw new Error(
+            `Value for argument variable "value", "${value}", is not valid`,
+        );
 
-        if (validate.css(value).error)
-            throw new Error(
-                `Value for argument variable "value", "${value}", is not valid`,
-            );
+        this.cssRoute.push({
+            value: this[_sanitize](value),
+            type: 'module'
+        });
 
-        this.cssRoute = this[_sanitize](value);
-
-        return this[_sanitize](this.cssRoute, prefix);
+        return this[_sanitize](value, prefix);
     }
 
     js({ value = null, prefix = false } = {}) {
         if (!value) {
-            return this[_sanitize](this.jsRoute, prefix);
+            const v = this[_compabillity](this.jsRoute);
+            return this[_sanitize](v, prefix);
         }
 
-        if (this.jsRoute) {
-            throw new Error('Value for "js" has already been set');
-        }
+        if (validate.js(value).error) throw new Error(
+            `Value for argument variable "value", "${value}", is not valid`,
+        );
 
-        if (validate.js(value).error)
-            throw new Error(
-                `Value for argument variable "value", "${value}", is not valid`,
-            );
+        this.jsRoute.push({
+            value: this[_sanitize](value),
+            type: 'module'
+        });
 
-        this.jsRoute = this[_sanitize](value);
-
-        return this[_sanitize](this.jsRoute, prefix);
+        return this[_sanitize](value, prefix);
     }
 
     view(fn = null) {
@@ -251,6 +248,13 @@ const PodiumLayout = class PodiumLayout {
             return uriIsRelative(uri) ? pathnameBuilder(pathname, uri) : uri;
         }
         return uri;
+    }
+
+    // This is here only to cater for compabillity between version 3 and 4
+    // Can be removed when deprecation of the .assets terminated
+    [_compabillity](arr) {
+        const result = arr.map(obj => { return obj.value });
+        return (result.length === 0) ? '' : result[0];
     }
 };
 


### PR DESCRIPTION
This removes the limitation of how many assets can be set. In v3.x this was limited to one asset (a bundle) but in v4 we opened for this being multiple. 

In other words; one can now do as follow:

```js
const layout = new Layout({ ... });
layout.css({ value: 'a.css' });
layout.css({ value: 'b.css' });
layout.css({ value: 'c.css' });
```