### PR TITLE
Added type as argument to .js method

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,20 +384,17 @@ When a value is set it will be kept internally and returned when the method is c
 
 ### options
 
-| option | type      | default | required |
-| ------ | --------- | ------- | -------- |
-| value  | `string`  |         |          |
-| prefix | `boolean` | `false` |          |
+| option | type      | default   | required |
+| ------ | --------- | --------- | -------- |
+| value  | `string`  |           |          |
+| prefix | `boolean` | `false`   |          |
+| type   | `string`  | `default` |          |
 
 #### value
 
 Used to set the pathname for the JavaScript assets for the Layout. The value
 can be a URL at which the Layout's user facing JavaScript is served. The value
 can be the [pathname] of a [URL] or an absolute URL.
-
-The value can only be set once. If called multiple times with a value, the
-method will throw. The method can, however, be called multiple times to
-retrieve the value.
 
 _Examples:_
 
@@ -460,6 +457,11 @@ layout.js({ value: '/assets/main.js', prefix: true });
 ```
 
 Prefix will be ignored if the returned value is an absolute URL.
+
+#### type
+
+Set the type of script which is set. `default` indicates an unknown type.
+`module` inidcates as ES6 module.
 
 ### .css(pathname)
 

--- a/__tests__/__snapshots__/layout.js.snap
+++ b/__tests__/__snapshots__/layout.js.snap
@@ -8,7 +8,7 @@ exports[`Layout() - rendering using a string - with assets 1`] = `
         <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
         <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\">
         <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://url.com/some/css\\">
-        <script src=\\"http://url.com/some/js\\" defer></script>
+        <script defer src=\\"http://url.com/some/js\\" ></script>
         <title>awesome page</title>
         extra head stuff
     </head>

--- a/__tests__/layout.js
+++ b/__tests__/layout.js
@@ -354,6 +354,15 @@ test('.js() - call method twice with a value for "value" argument - should set b
     expect(result).toEqual('/foo/bar');
 });
 
+test('.js() - "type" argument is set to "module" - should set "type" to "module"', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.js({ value: '/foo/bar' });
+    layout.js({ value: '/bar/foo', type: 'module' });
+
+    const result = layout.jsRoute;
+    expect(result).toEqual([{ type: "default", value: "/foo/bar" }, { type: "module", value: "/bar/foo" }]);
+});
+
 test('Layout() - rendering using an object', async () => {
     expect.hasAssertions();
 

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -161,8 +161,8 @@ const PodiumLayout = class PodiumLayout {
     async process(incoming) {
         incoming.name = this.name;
         incoming.view = this._view;
-        incoming.js = this.js();
-        incoming.css = this.css();
+        incoming.js = this.jsRoute;
+        incoming.css = this.cssRoute;
 
         await this.context.process(incoming);
         await this.httpProxy.process(incoming);
@@ -180,13 +180,13 @@ const PodiumLayout = class PodiumLayout {
 
         this.cssRoute.push({
             value: this[_sanitize](value),
-            type: 'module'
+            type: 'default',
         });
 
         return this[_sanitize](value, prefix);
     }
 
-    js({ value = null, prefix = false } = {}) {
+    js({ value = null, prefix = false, type = 'default' } = {}) {
         if (!value) {
             const v = this[_compabillity](this.jsRoute);
             return this[_sanitize](v, prefix);
@@ -198,7 +198,7 @@ const PodiumLayout = class PodiumLayout {
 
         this.jsRoute.push({
             value: this[_sanitize](value),
-            type: 'module'
+            type,
         });
 
         return this[_sanitize](value, prefix);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@podium/context": "4.0.0-next.2",
     "@podium/proxy": "4.0.0-next.3",
     "@podium/schemas": "4.0.0-next.3",
-    "@podium/utils": "4.0.0-next.2",
+    "@podium/utils": "4.0.0-next.4",
     "abslog": "2.4.0",
     "objobj": "^1.0.0",
     "lodash.merge": "^4.6.1",


### PR DESCRIPTION
This adds `type` as argument to the `.js()` method. It also sets the default value to `default`. This will normally be used to define which type of script we have and can be used to reflect this in `<script>` tags.

Example: `type` set to `module` will set `<script type="module">` in the default template making it possible to load ES6 modules directly.