### PR TITLE
Made proxying and context in the process method configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ const layout = new Layout({
 
 The Layout instance has the following API:
 
-### .process(HttpIncoming)
+### .process(HttpIncoming, options)
 
 Method for processing an incoming HTTP request. This method is intended to be
 used to implement support for multiple HTTP frameworks and it should not normally be
@@ -270,6 +270,13 @@ app.use(async (req, res, next) => {
     }
 });
 ```
+
+#### options
+
+| option  | default | type      | required | details                                                                   |
+| ------- | ------- | --------- | -------- | ------------------------------------------------------------------------- |
+| context | `true`  | `boolean` | `false`  | If `@podium/context` should be applied as part of the `.process()` method |
+| proxy   | `true`  | `boolean` | `false`  | If `@podium/proxy` should be applied as part of the `.process()` method   |
 
 ### .render(httpIncoming, data)
 

--- a/__tests__/layout.js
+++ b/__tests__/layout.js
@@ -1,11 +1,21 @@
 'use strict';
 
-const Podlet = require('@podium/podlet');
+const { HttpIncoming } = require('@podium/utils');
 const stoppable = require('stoppable');
 const express = require('express');
 const request = require('supertest');
+const Podlet = require('@podium/podlet');
 const stream = require('readable-stream');
+
 const Layout = require('../');
+
+const SIMPLE_REQ = {
+    headers: {},
+};
+
+const SIMPLE_RES = {
+    locals: {},
+};
 
 const destObjectStream = done => {
     const arr = [];
@@ -361,6 +371,17 @@ test('.js() - "type" argument is set to "module" - should set "type" to "module"
 
     const result = layout.jsRoute;
     expect(result).toEqual([{ type: "default", value: "/foo/bar" }, { type: "module", value: "/bar/foo" }]);
+});
+
+// #############################################
+// .process()
+// #############################################
+
+test('.process() - call method with HttpIncoming - should return HttpIncoming', async () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    const result = await layout.process(incoming);
+    expect(result).toEqual(incoming);
 });
 
 test('Layout() - rendering using an object', async () => {

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -158,16 +158,6 @@ const PodiumLayout = class PodiumLayout {
         return 'PodiumLayout';
     }
 
-    async process(incoming) {
-        incoming.name = this.name;
-        incoming.view = this._view;
-        incoming.js = this.jsRoute;
-        incoming.css = this.cssRoute;
-
-        await this.context.process(incoming);
-        await this.httpProxy.process(incoming);
-    }
-
     css({ value = null, prefix = false } = {}) {
         if (!value) {
             const v = this[_compabillity](this.cssRoute);
@@ -215,6 +205,18 @@ const PodiumLayout = class PodiumLayout {
 
     render(incoming, data) {
         return incoming.render(data);
+    }
+
+    async process(incoming, { proxy = true, context = true } = {}) {
+        incoming.name = this.name;
+        incoming.view = this._view;
+        incoming.css = this.cssRoute;
+        incoming.js = this.jsRoute;
+
+        if (context) await this.context.process(incoming);
+        if (proxy) await this.httpProxy.process(incoming);
+
+        return incoming;
     }
 
     middleware() {


### PR DESCRIPTION
This adds a options argument to the `layout.process()` method with a `proxy` and `context` property which can be `true` or `false`.

The reason behind adding this it that inside the `podlet.process()` method we set sertain properties on `HttpIncoming` pluss calling the `proxy.process()` and `context.process()` method for doing proxying and appending context. This works fine when doing setup as in a Express middelware, but in some http frameworks we need to separate the process of setting properties on `HttpIncoming` and setting up the proxy and appending context by calling `proxy.process()` and `context.process()`. 

The new option property `proxy` and `context` makes it possible to turn the setup of proxying and context inside `layout.process()` on or off making it easier to implement support for different http frameworks.