### PR TITLE
Use @podium/test-utils for destination stream

### DIFF
--- a/__tests__/layout.js
+++ b/__tests__/layout.js
@@ -1,11 +1,11 @@
 'use strict';
 
+const { destinationObjectStream } = require('@podium/test-utils');
 const { HttpIncoming } = require('@podium/utils');
 const stoppable = require('stoppable');
 const express = require('express');
 const request = require('supertest');
 const Podlet = require('@podium/podlet');
-const stream = require('readable-stream');
 
 const Layout = require('../');
 
@@ -15,24 +15,6 @@ const SIMPLE_REQ = {
 
 const SIMPLE_RES = {
     locals: {},
-};
-
-const destObjectStream = done => {
-    const arr = [];
-
-    const dStream = new stream.Writable({
-        objectMode: true,
-        write(chunk, encoding, callback) {
-            arr.push(chunk);
-            callback();
-        },
-    });
-
-    dStream.on('finish', () => {
-        done(arr);
-    });
-
-    return dStream;
 };
 
 const DEFAULT_OPTIONS = { name: 'foo', pathname: '/' };
@@ -94,7 +76,7 @@ test('Layout() - should collect metric with version info', done => {
 
     const layout = new Layout(DEFAULT_OPTIONS);
 
-    const dest = destObjectStream(arr => {
+    const dest = destinationObjectStream(arr => {
         expect(arr[0]).toMatchObject({
             name: 'podium_layout_version_info',
             labels: [
@@ -175,7 +157,7 @@ test('Layout() - metrics properly decorated', async done => {
     });
 
     layout.metrics.pipe(
-        destObjectStream(arr => {
+        destinationObjectStream(arr => {
             expect(arr[0].name).toBe('podium_layout_version_info');
             expect(arr[0].type).toBe(1);
             expect(arr[0].value).toBe(1);

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "@podium/utils": "4.0.0-next.4",
     "abslog": "2.4.0",
     "objobj": "^1.0.0",
-    "lodash.merge": "^4.6.1",
-    "readable-stream": "^3.2.0"
+    "lodash.merge": "^4.6.1"
   },
   "devDependencies": {
+    "@podium/test-utils": "1.1.0",
     "eslint": "^5.14.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^4.0.0",


### PR DESCRIPTION
Replaces the internal destination stream helper method with the one in @podium/test-utils.