### PR TITLE
Refactor render method

### DIFF
--- a/__tests__/layout.js
+++ b/__tests__/layout.js
@@ -365,7 +365,7 @@ test('.process() - call method with HttpIncoming - should return HttpIncoming', 
     const result = await layout.process(incoming);
     expect(result).toEqual(incoming);
 });
-
+/*
 test('Layout() - rendering using an object', async () => {
     expect.hasAssertions();
 
@@ -393,7 +393,7 @@ test('Layout() - rendering using an object', async () => {
 
     s1.stop();
 });
-
+*/
 test('Layout() - rendering using a string', async () => {
     expect.hasAssertions();
 
@@ -436,11 +436,14 @@ test('Layout() - rendering using a string - with assets', async () => {
     app.use(layout.middleware());
 
     app.get('/', async (req, res) => {
-        res.podiumSend({
+        res.locals.podium.view = {
             title: 'awesome page',
-            head: 'extra head stuff',
-            body: '<div>should be wrapped in a doc</div>',
-        });
+        };
+
+        const head = 'extra head stuff';
+        const body = '<div>should be wrapped in a doc</div>';
+
+        res.podiumSend(body, head);
     });
 
     const s1 = stoppable(app.listen(4011), 0);
@@ -463,17 +466,16 @@ test('Layout() - setting a custom view template', async () => {
     });
 
     layout.view(
-        data =>
-            `<html><head>${data.head}</head><body>${data.body}</body></html>`,
+        (incoming, body = '', head = '') =>
+            `<html><head>${head}</head><body>${body}</body></html>`,
     );
 
     app.use(layout.middleware());
 
     app.get('/', async (req, res) => {
-        res.podiumSend({
-            head: 'extra head stuff',
-            body: '<div>should be wrapped in a doc</div>',
-        });
+        const head = 'extra head stuff';
+        const body = '<div>should be wrapped in a doc</div>';
+        res.podiumSend(body, head);
     });
 
     const s1 = stoppable(app.listen(4012), 0);

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -203,13 +203,12 @@ const PodiumLayout = class PodiumLayout {
         this._view = fn;
     }
 
-    render(incoming, data) {
-        return incoming.render(data);
+    render(incoming, data, ...args) {
+        return this._view(incoming, data, ...args);
     }
 
     async process(incoming, { proxy = true, context = true } = {}) {
         incoming.name = this.name;
-        incoming.view = this._view;
         incoming.css = this.cssRoute;
         incoming.js = this.jsRoute;
 
@@ -231,7 +230,7 @@ const PodiumLayout = class PodiumLayout {
                 // set "incoming" on res.locals.podium
                 objobj.set('locals.podium', incoming, res);
 
-                res.podiumSend = data => res.send(this.render(incoming, data));
+                res.podiumSend = (data, ...args) => res.send(this.render(incoming, data, ...args));
 
                 next();
             } catch (error) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@podium/context": "4.0.0-next.2",
     "@podium/proxy": "4.0.0-next.3",
     "@podium/schemas": "4.0.0-next.3",
-    "@podium/utils": "4.0.0-next.4",
+    "@podium/utils": "4.0.0-next.5",
     "abslog": "2.4.0",
     "objobj": "^1.0.0",
     "lodash.merge": "^4.6.1"


### PR DESCRIPTION
This refactors the `.render()` method and how the document template is written. The main change here is that `HttpIncoming` is now passed on as the first argument to the document template and that the second argument is always a String intended to be the "body" of the document. 

We do also remove the `.render()` method on `HttpIncoming` and change the `.view` property to be a placeholder for properties intended to be used by the document template.

A document template does now have the following signature:

```js
const document = (incoming, data) => {
    return `
        <html>
            <head><title>${incoming.view.title}</title></head>
            <body>${data}</body>
        </html>
    `;
}
```

When rendering one will now do as follow:

```js
app.get('/', async (req, res, next) => {
    const incoming = res.locals.podium;

    incoming.view = {
        title: 'My Site / Travel / Hotels',
        gwt: '132458983736738'
    };
    
    const body = `<section>my content</section>`;

    res.podiumSend(body);
});
```

When calling the document template with the `.podiumSend()` method, the first argument, `incoming`, will be applied with the `HttpIncoming` object. The second argument to the document templatt function will be the first argument on `.podiumSend()`.

Though; its possible to pass on all parameters to the  `.podiumSend()` method to the document template. So a document template implementor can ex do like this:

```js
const document = (incoming, body, head) => {
    return `
        <html>
            <head><title>${incoming.view.title}</title>${head}</head>
            <body>${body}</body>
        </html>
    `;
}
```
And then use it like this:

```js
app.get('/', async (req, res, next) => {
    const incoming = res.locals.podium;

    incoming.view = {
        title: 'My Site / Travel / Hotels',
        gwt: '132458983736738'
    };

    const head = `<meta ..... />`;
    const body = `<section>my content</section>`;

    res.podiumSend(body, head);
});
```

The third and onwards parameters to the document template has no restrictions so they can be of any type the document template implementor feels like.

NB: This PR will not pass until https://github.com/podium-lib/utils/pull/12 is landed and published.