### PR TITLE
Refactor js() and css() methods to support arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,8 +386,9 @@ app.get(`${layout.pathname()}/bar/:id`, (req, res, next) => {
 
 ### .js(options)
 
-Sets and returns the pathname for a Layout's JavaScript assets. Defaults to an
-empty String.
+Sets the pathname for a Layout's JavaScript assets.
+
+`options` can be either an object or an array of options objects as described below.
 
 When a value is set it will be kept internally and returned when the method is called again.
 
@@ -416,9 +417,11 @@ const layout = new Layout({
     pathname: '/',
 });
 
-app.get(layout.js({ value: '/assets/main.js' }), (req, res) => {
-    res.status(200).sendFile('./app/assets/main.js', err => {});
-});
+layout.js({ value: '/assets/main.js' });
+
+// or
+
+layout.js([{ value: '/assets/main.js' }, { value: '/assets/secondary.js' }]);
 ```
 
 Serve assets statically along side the app and set a relative URI to the
@@ -472,10 +475,11 @@ Prefix will be ignored if the returned value is an absolute URL.
 Set the type of script which is set. `default` indicates an unknown type.
 `module` inidcates as ES6 module.
 
-### .css(pathname)
+### .css(options)
 
-Sets and returns the pathname for a Layout's CSS assets. Defaults to an empty
-String.
+Sets the pathname for a Layout's CSS assets.
+
+`options` can be either an object or an array of options objects as described below.
 
 When a value is set it will be kept internally and returned when the method is called again.
 
@@ -507,9 +511,11 @@ const layout = new Layout({
     pathname: '/',
 });
 
-app.get(layout.css({ value: '/assets/main.css' }), (req, res) => {
-    res.status(200).sendFile('./app/assets/main.css', err => {});
-});
+layout.css({ value: '/assets/main.css' });
+
+// or
+
+layout.css([{ value: '/assets/main.css' }, { value: '/assets/secondary.css' }]);
 ```
 
 Serve assets from a static file server and set a relative URI to the CSS file:

--- a/__tests__/layout.js
+++ b/__tests__/layout.js
@@ -284,6 +284,42 @@ test('.css() - call method twice with a value for "value" argument - should set 
     expect(result).toEqual('/foo/bar');
 });
 
+test('.css() - "options" argument as an array - should accept an array of values', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.css([{ value: '/foo/bar' }, { value: '/bar/foo' }]);
+
+    expect(layout.cssRoute).toEqual([
+        { type: 'default', value: '/foo/bar' },
+        { type: 'default', value: '/bar/foo' },
+    ]);
+});
+
+test('.css() - "options" argument as an array - call method twice - should set all values', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.css([{ value: '/foo/bar' }, { value: '/bar/foo' }]);
+    layout.css([{ value: '/foo/bar/baz' }, { value: '/bar/foo/baz' }]);
+
+    expect(layout.cssRoute).toEqual([
+        { type: 'default', value: '/foo/bar' },
+        { type: 'default', value: '/bar/foo' },
+        { type: 'default', value: '/foo/bar/baz' },
+        { type: 'default', value: '/bar/foo/baz' },
+    ]);
+});
+
+test('.css() - "options" argument as an array - should set additional keys', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.css([
+        { value: '/foo/bar', fake: 'prop' },
+        { value: '/bar/foo', prop: 'fake' },
+    ]);
+
+    expect(layout.cssRoute).toEqual([
+        { type: 'default', value: '/foo/bar', fake: 'prop' },
+        { type: 'default', value: '/bar/foo', prop: 'fake' },
+    ]);
+});
+
 // #############################################
 // .js()
 // #############################################
@@ -352,7 +388,49 @@ test('.js() - "type" argument is set to "module" - should set "type" to "module"
     layout.js({ value: '/bar/foo', type: 'module' });
 
     const result = layout.jsRoute;
-    expect(result).toEqual([{ type: "default", value: "/foo/bar" }, { type: "module", value: "/bar/foo" }]);
+    expect(result).toEqual([
+        { type: 'default', value: '/foo/bar' },
+        { type: 'module', value: '/bar/foo' },
+    ]);
+});
+
+test('.js() - "options" argument as an array - should accept an array of values', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.js([{ value: '/foo/bar' }, { value: '/bar/foo', type: 'module' }]);
+
+    expect(layout.jsRoute).toEqual([
+        { type: 'default', value: '/foo/bar' },
+        { type: 'module', value: '/bar/foo' },
+    ]);
+});
+
+test('.js() - "options" argument as an array - call method twice - should set all values', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.js([{ value: '/foo/bar' }, { value: '/bar/foo', type: 'module' }]);
+    layout.js([
+        { value: '/foo/bar/baz' },
+        { value: '/bar/foo/baz', type: 'module' },
+    ]);
+
+    expect(layout.jsRoute).toEqual([
+        { type: 'default', value: '/foo/bar' },
+        { type: 'module', value: '/bar/foo' },
+        { type: 'default', value: '/foo/bar/baz' },
+        { type: 'module', value: '/bar/foo/baz' },
+    ]);
+});
+
+test('.js() - "options" argument as an array - should set additional keys', () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.js([
+        { value: '/foo/bar', fake: 'prop' },
+        { value: '/bar/foo', type: 'module', prop: 'fake' },
+    ]);
+
+    expect(layout.jsRoute).toEqual([
+        { type: 'default', value: '/foo/bar', fake: 'prop' },
+        { type: 'module', value: '/bar/foo', prop: 'fake' },
+    ]);
 });
 
 // #############################################

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -1,4 +1,6 @@
+/* eslint-disable consistent-return */
 /* eslint-disable no-underscore-dangle */
+/* eslint-disable no-restricted-syntax */
 
 'use strict';
 
@@ -22,6 +24,28 @@ const pkg = require('../package.json');
 const _compabillity = Symbol('_compabillity');
 const _pathname = Symbol('_pathname');
 const _sanitize = Symbol('_sanitize');
+const _addCssAsset = Symbol('_addCssAsset');
+const _addJsAsset = Symbol('_addJsAsset');
+
+function deprecateJsReturn() {
+    if (!deprecateJsReturn.warned) {
+        deprecateJsReturn.warned = true;
+        process.emitWarning(
+            'Return value from method js() is now deprecated and will be removed in a future version. Please do not rely on this value.',
+            'DeprecationWarning',
+        );
+    }
+}
+
+function deprecateCssReturn() {
+    if (!deprecateCssReturn.warned) {
+        deprecateCssReturn.warned = true;
+        process.emitWarning(
+            'Return value from method css() is now deprecated and will be removed in a future version. Please do not rely on this value.',
+            'DeprecationWarning',
+        );
+    }
+}
 
 const PodiumLayout = class PodiumLayout {
     /* istanbul ignore next */
@@ -158,40 +182,80 @@ const PodiumLayout = class PodiumLayout {
         return 'PodiumLayout';
     }
 
-    css({ value = null, prefix = false } = {}) {
+    [_addCssAsset]({ value = null, prefix = false, ...rest } = {}) {
         if (!value) {
             const v = this[_compabillity](this.cssRoute);
             return this[_sanitize](v, prefix);
         }
 
-        if (validate.css(value).error) throw new Error(
-            `Value for argument variable "value", "${value}", is not valid`,
-        );
+        if (validate.css(value).error)
+            throw new Error(
+                `Value for argument variable "value", "${value}", is not valid`,
+            );
 
         this.cssRoute.push({
             value: this[_sanitize](value),
             type: 'default',
+            ...rest,
         });
 
+        // deprecate
+        deprecateCssReturn();
         return this[_sanitize](value, prefix);
     }
 
-    js({ value = null, prefix = false, type = 'default' } = {}) {
+    css(options = {}) {
+        if (Array.isArray(options)) {
+            for (const opts of options) {
+                this[_addCssAsset](opts);
+            }
+        } else {
+            const { value = null, prefix = false, ...rest } = options;
+            return this[_addCssAsset]({ value, prefix, ...rest });
+        }
+    }
+
+    [_addJsAsset]({
+        value = null,
+        prefix = false,
+        type = 'default',
+        ...rest
+    } = {}) {
         if (!value) {
             const v = this[_compabillity](this.jsRoute);
             return this[_sanitize](v, prefix);
         }
 
-        if (validate.js(value).error) throw new Error(
-            `Value for argument variable "value", "${value}", is not valid`,
-        );
+        if (validate.js(value).error)
+            throw new Error(
+                `Value for argument variable "value", "${value}", is not valid`,
+            );
 
         this.jsRoute.push({
             value: this[_sanitize](value),
             type,
+            ...rest,
         });
 
+        // deprecate
+        deprecateJsReturn();
         return this[_sanitize](value, prefix);
+    }
+
+    js(options = {}) {
+        if (Array.isArray(options)) {
+            for (const opts of options) {
+                this[_addJsAsset](opts);
+            }
+        } else {
+            const {
+                value = null,
+                prefix = false,
+                type = 'default',
+                ...rest
+            } = options;
+            return this[_addJsAsset]({ value, prefix, type, ...rest });
+        }
     }
 
     view(fn = null) {
@@ -230,7 +294,8 @@ const PodiumLayout = class PodiumLayout {
                 // set "incoming" on res.locals.podium
                 objobj.set('locals.podium', incoming, res);
 
-                res.podiumSend = (data, ...args) => res.send(this.render(incoming, data, ...args));
+                res.podiumSend = (data, ...args) =>
+                    res.send(this.render(incoming, data, ...args));
 
                 next();
             } catch (error) {
@@ -254,8 +319,10 @@ const PodiumLayout = class PodiumLayout {
     // This is here only to cater for compabillity between version 3 and 4
     // Can be removed when deprecation of the .assets terminated
     [_compabillity](arr) {
-        const result = arr.map(obj => { return obj.value });
-        return (result.length === 0) ? '' : result[0];
+        const result = arr.map(obj => {
+            return obj.value;
+        });
+        return result.length === 0 ? '' : result[0];
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
   "devDependencies": {
     "@podium/test-utils": "1.6.3",
     "eslint": "^6.0.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-config-airbnb-base": "^13.2.0",
     "eslint-config-prettier": "^6.0.0",
-    "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-import": "^2.18.0",
+    "eslint-plugin-prettier": "^3.1.0",
     "express": "^4.16.4",
     "hbs": "^4.0.2",
     "husky": "^2.4.1",


### PR DESCRIPTION
* add support for array syntax 
* add support for additional properties
* add deprecation warnings for return values

This PR mirrors the changes in https://github.com/podium-lib/podlet/pull/54
