### PR TITLE
add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,49 @@
+import { HttpIncoming, AssetJs, AssetCss } from '@podium/utils';
+import PodiumClient from '@podium/client';
+
+// Use declaration merging to extend Express.
+declare global {
+    namespace Express {
+        interface Response {
+            podiumSend(fragment: string, ...args: unknown[]): Response;
+        }
+    }
+}
+
+export interface LayoutOptions {
+    name: string;
+    pathname: string;
+    logger?: any;
+    context?: {};
+    client?: {};
+    proxy?: {};
+}
+
+export default class Layout {
+
+    readonly client: PodiumClient;
+    readonly metrics: any;
+    readonly context: any;
+
+    constructor(options: LayoutOptions);
+
+    middleware(): (req: any, res: any, next: any) => Promise<void>;
+
+    pathname(): string;
+
+    js(options: AssetJs | Array<AssetJs>): void;
+
+    css(options: AssetCss | Array<AssetCss>): void;
+
+    view(
+        template: (
+            incoming: HttpIncoming,
+            fragment: string,
+            ...args: unknown[]
+        ) => string,
+    ): void
+
+    render(incoming: HttpIncoming, fragment: string, ...args: unknown[]): string;
+
+    process(incoming: HttpIncoming): Promise<HttpIncoming>;
+}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   },
   "homepage": "https://podium-lib.io/",
   "files": [
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
@@ -38,8 +40,8 @@
     "@podium/schemas": "4.0.0",
     "@podium/utils": "4.1.0-next.2",
     "abslog": "2.4.0",
-    "objobj": "1.0.0",
-    "lodash.merge": "4.6.2"
+    "lodash.merge": "4.6.2",
+    "objobj": "1.0.0"
   },
   "devDependencies": {
     "@podium/test-utils": "1.6.3",


### PR DESCRIPTION
This pull request adds TypeScript declarations to this module.

Since we have first class support for Express I've added the podiumSend method to the express response type. This is achieved through declaration merging.

A minor issue is that the method doesn't exist unless the layout's middleware has been hooked up in express, but we have no way of typing this (that I know of).