### PR TITLE
create new asset arrays for HttpIncoming in middleware

### DIFF
--- a/__tests__/layout.js
+++ b/__tests__/layout.js
@@ -2,6 +2,7 @@
 
 const { destinationObjectStream } = require('@podium/test-utils');
 const { HttpIncoming, AssetJs, AssetCss } = require('@podium/utils');
+const PodletClientResponse = require('@podium/client/lib/response');
 const stoppable = require('stoppable');
 const express = require('express');
 const request = require('supertest');
@@ -472,6 +473,28 @@ test('.process() - call method with HttpIncoming - should return HttpIncoming', 
     const result = await layout.process(incoming);
     expect(result).toEqual(incoming);
 });
+
+test('.process() - idempotence - manipulating the HttpIncoming should not affect layout', async () => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    expect(layout.jsRoute).toEqual([]);
+    expect(layout.cssRoute).toEqual([]);
+
+    // Simulate middleware
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    await layout.process(incoming);
+
+    // Simulate layout route
+    incoming.podlets = [
+        new PodletClientResponse({
+            js: [{ value: '/foo/bar' }],
+            css: [{ value: '/bar/foo' }],
+        }),
+    ];
+
+    expect(layout.jsRoute).toEqual([]);
+    expect(layout.cssRoute).toEqual([]);
+});
+
 /*
 test('Layout() - rendering using an object', async () => {
     expect.hasAssertions();

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -249,8 +249,8 @@ const PodiumLayout = class PodiumLayout {
 
     async process(incoming, { proxy = true, context = true } = {}) {
         incoming.name = this.name;
-        incoming.css = this.cssRoute;
-        incoming.js = this.jsRoute;
+        incoming.css = [...this.cssRoute];
+        incoming.js = [...this.jsRoute];
 
         if (context) await this.context.process(incoming);
         if (proxy) await this.httpProxy.process(incoming);


### PR DESCRIPTION
This pull request fixes an issue where using `incoming.podlets` on the HttpIncoming object would alter the internal layout asset lists.

This is a simplifcation of the code that caused me to find this bug:
```js
app.get(layout.pathname(), async (req, res) => {
  const incoming = res.locals.podium;

  const response = await Promise.all([
    podlet.fetch(incoming)
  ]);

  incoming.podlets = response;

  res.podiumSend(....)
})
```

`incoming.podlets` uses push to append CSS and JS assets from the podlet responses.

The problem was that layout initializes the HttpIncoming object with the layout's own assets, by passing a reference it's internal asset arrays. This meant that every push by `incoming.podlets` modified the layout asset array, on every request.

After a couple of requests, you're suddenly in a situation like this:
<img width="622" alt="Screenshot 2019-11-20 at 13 56 08" src="https://user-images.githubusercontent.com/81577/69248589-d12eb100-0bac-11ea-95c7-6c5b0901687d.png">

Fixed the bug by creating a new arrays in the middleware.
 




