### PR TITLE
Inherit URL values from Express

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -261,7 +261,7 @@ const PodiumLayout = class PodiumLayout {
     middleware() {
         return async (req, res, next) => {
             const incoming = new HttpIncoming(req, res, res.locals);
-
+            incoming.url = new URL(req.originalUrl, `${req.protocol}://${req.get('host')}`);
             try {
                 await this.process(incoming);
                 // if this is a proxy request then no further work should be done.


### PR DESCRIPTION
This make it so that we inherit the URL values from express and depend on those instead of parsing out these by our self.

The advantage of this is that we are then moving the responsibility of handling `x-forwarded` headers etc to Express and is not an extra thing in Podium. It improves security and makes the URL values in Express content and Podium identical.