### PR TITLE
feat: Added support for data-* attributes on .js() method

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -217,6 +217,19 @@ const PodiumLayout = class PodiumLayout {
 
         const clonedOptions = JSON.parse(JSON.stringify(options));
         const args = { ...clonedOptions, pathname: this._pathname };
+
+        // Convert data attribute object structure to array of key value objects
+        if (typeof args.data === 'object' && args.data !== null) {
+            const data = [];
+            Object.keys(args.data).forEach((key) => {
+                data.push({
+                    value: args.data[key],
+                    key,
+                });
+            })
+            args.data = data;
+        }
+
         this.jsRoute.push(new AssetJs(args));
 
         // deprecate

--- a/tests/layout.js
+++ b/tests/layout.js
@@ -443,6 +443,37 @@ test('.js() - "options" argument as an array - should NOT set additional keys', 
     t.end();
 });
 
+test('.js() - data attribute object - should convert to array of key / value objects', (t) => {
+    const layout = new Layout(DEFAULT_OPTIONS);
+    layout.js([
+        { 
+            value: '/foo/bar',
+            data: {
+                bar: 'a',
+                foo: 'b'
+            } 
+        }
+    ]);
+
+    const result = JSON.parse(JSON.stringify(layout.jsRoute));
+
+    t.same(result, [{ 
+        type: 'default', 
+        value: '/foo/bar',
+        data: [
+            {
+                key: 'bar',
+                value: 'a',
+            },
+            {
+                key: 'foo',
+                value: 'b',
+            }
+        ] 
+    }]);
+    t.end()
+});
+
 // #############################################
 // .process()
 // #############################################


### PR DESCRIPTION
This adds support for setting data attributes through the `.js()` method like so:

```js
layout.js([
    { 
        value: '/assets/script.js',
        data: {
            bar: 'a',
            foo: 'b'
        } 
    }
]);
```

This will then be represented in the html template like so:

```html
<script src="/assets/script.js" data-bar="a" data-foo="b"></script>
```

Originally suggested in https://github.com/podium-lib/utils/pull/58