### PR TITLE
fix: point types at correct types file

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lib"
   ],
   "main": "./lib/layout.js",
-  "types": "index.d.ts",
+  "types": "layout.d.ts",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",


### PR DESCRIPTION
Not sure how this got changed to the wrong value as it was correct on next at one point. In any case, here's the fix.