### PR TITLE
fix: Proxy path is wrongly using name from manifest instead of given name when registered

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -145,7 +145,7 @@ export default class PodiumLayout {
 
         // Register proxy endpoints
         this.client.registry.on('set', (key, item) => {
-            this.httpProxy.register(item.newVal);
+            this.httpProxy.register(key, item.newVal);
         });
     }
 
@@ -228,6 +228,8 @@ export default class PodiumLayout {
     middleware() {
         return async (req, res, next) => {
             const incoming = new HttpIncoming(req, res, res.locals);
+            incoming.url = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+
             try {
                 await this.process(incoming);
                 // if this is a proxy request then no further work should be done.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@metrics/client": "2.5.2",
     "@podium/client": "5.0.2",
     "@podium/context": "5.0.0",
-    "@podium/proxy": "5.0.0",
+    "@podium/proxy": "5.0.2",
     "@podium/schemas": "5.0.0",
     "@podium/utils": "5.0.0",
     "abslog": "2.4.0",


### PR DESCRIPTION
This test serves to illustrate and test against the issue we are seeing between Podium v4 and v5 layouts wrt proxying. 

As of Pv5, the layout has started building proxy paths using the podlet name value supplied by the podlet manifest file while in Pv4 it used the name value supplied in the layout by the layout.client.register call.

Podium v4
```js
// podlet
const podlet = new Podlet({ name: 'foo' })
podlet.proxy({ target: '/api', name: 'bar' })

// layout
layout.client.register({ name: 'baz', ... });
// proxy endpoint mounted at /podium-resource/baz/bar
```

Podium v5
```js
// podlet
const podlet = new Podlet({ name: 'foo' })
podlet.proxy({ target: '/api', name: 'bar' })

// layout
layout.client.register({ name: 'baz', ... });
// proxy endpoint mounted at /podium-resource/foo/bar
```

N.B. This test case does not cover the protocol issue we are also seeing where mountOrigin in the podlet is using http when it should be https.