### PR TITLE
feat: reexport types from podium/client

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -18,6 +18,19 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 
+// Re-export these types from @podium/client so folks can avoid
+// installing it just for types (and then getting out of sync
+// causing type issues because of different versions from
+// @podium/layout).
+/**
+ * @typedef {import('@podium/client').PodiumClientResource} PodiumClientResource
+ * @typedef {import('@podium/client').PodiumClientResourceOptions} PodiumClientResourceOptions
+ * @typedef {import('@podium/client').PodiumClientResponse} PodiumClientResponse
+ * @typedef {import('@podium/client').PodiumRedirect} PodiumRedirect
+ * @typedef {import('@podium/client').PodletManifest} PodletManifest
+ * @typedef {import('@podium/client').RegisterOptions} RegisterOptions
+ */
+
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const pkgJson = fs.readFileSync(
     join(currentDirectory, '../package.json'),

--- a/package.json
+++ b/package.json
@@ -32,12 +32,11 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "test": "run-s test:unit test:types",
-    "test:unit": "tap --disable-coverage --allow-empty-coverage",
-    "test:types": "tsc --project tsconfig.test.json",
+    "test": "tap --disable-coverage --allow-empty-coverage",
     "test:snapshots": "tap --snapshot --disable-coverage --allow-empty-coverage",
-    "types": "run-s types:tsc types:fixup",
+    "types": "run-s types:tsc types:fixup types:test",
     "types:tsc": "tsc --declaration --emitDeclarationOnly",
+    "types:test": "tsc --project tsconfig.test.json",
     "types:fixup": "node ./fixup.js"
   },
   "dependencies": {

--- a/tests/layout.test.js
+++ b/tests/layout.test.js
@@ -143,12 +143,17 @@ tap.test('Layout() - metrics properly decorated', (t) => {
 
     app.use(layout.middleware());
 
-    const podletClient = layout.client.register({
+    /** @type {import('../lib/layout.js').RegisterOptions} */
+    const options = {
         uri: 'http://0.0.0.0:5021/manifest.json',
         name: 'myPodlet',
-    });
+    };
+
+    /** @type {import('../lib/layout.js').PodiumClientResource} */
+    const podletClient = layout.client.register(options);
 
     app.get('/', async (req, res) => {
+        /** @type {import('../lib/layout.js').PodiumClientResponse} */
         const response = await podletClient.fetch(res.locals.podium);
         res.send(response.content);
     });


### PR DESCRIPTION
For TypeScript users sometimes the podium/client package (used only for types) would be updated to a newer version than what was used in the latest podium/layout package. This would cause unexpected type incompatibilities. From this version on, export the types from podium/client so TypeScript users can remove the direct dependency on podium/client, ensuring the types are always in sync with podium/layout.