### PR TITLE
fix: include layout_name in podium_layout_version_info

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -295,6 +295,7 @@ export default class PodiumLayout {
                     major: segments[0],
                     minor: segments[1],
                     patch: segments[2],
+                    layout_name: this.name,
                 },
             });
 


### PR DESCRIPTION
I'm a bit torn whether this should be a separate metric or not. The layout doesn't have much additional stuff, but see https://github.com/podium-lib/podlet/pull/432 for example.

We should stay consistent, so I guess my question is "do we stuff everything in `podium_layout_version_info` and `podium_podlet_version_info` or not?"