### PR TITLE
fix: update podium/client to get DNS lookup cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@metrics/client": "2.5.5",
-        "@podium/client": "5.4.12",
+        "@podium/client": "5.4.13",
         "@podium/context": "5.1.11",
         "@podium/proxy": "5.0.37",
         "@podium/schemas": "5.2.1",


### PR DESCRIPTION
Relates to https://github.com/podium-lib/client/issues/506